### PR TITLE
Caching implementation

### DIFF
--- a/samples/Application.Demo/Web.config
+++ b/samples/Application.Demo/Web.config
@@ -40,6 +40,7 @@
     <add key="Umbraco.ModelsBuilder.Enable" value="true" />
     <add key="Umbraco.ModelsBuilder.ModelsMode" value="AppData" />
     <add key="Umbraco.ModelsBuilder.ModelsNamespace" value="Application.Demo.Models" />
+    <add key="AllowedIpServiceCache:Enabled" value="true" />
   </appSettings>
   <!--
     Important: If you're upgrading Umbraco, do not clear the connection

--- a/src/Our.Umbraco.Gandalf/Core/Controllers/Backoffice/AllowedApiController.cs
+++ b/src/Our.Umbraco.Gandalf/Core/Controllers/Backoffice/AllowedApiController.cs
@@ -7,7 +7,6 @@ using System.Web.Mvc;
 using Umbraco.Web.Mvc;
 using Umbraco.Web.WebApi;
 using Our.Umbraco.Gandalf.Core.Models.Api.Request;
-using Our.Umbraco.Gandalf.Core.Services.CachedProxies;
 
 namespace Our.Umbraco.Gandalf.Controllers.Backoffice
 {
@@ -16,7 +15,7 @@ namespace Our.Umbraco.Gandalf.Controllers.Backoffice
     {
         private IAllowedIpService _allowedIpService;
 
-        public AllowedIpApiController(AllowedIpService allowedIpService)
+        public AllowedIpApiController(IAllowedIpService allowedIpService)
         {
 			_allowedIpService = allowedIpService;
         }

--- a/src/Our.Umbraco.Gandalf/Core/Controllers/Backoffice/AllowedApiController.cs
+++ b/src/Our.Umbraco.Gandalf/Core/Controllers/Backoffice/AllowedApiController.cs
@@ -14,18 +14,18 @@ namespace Our.Umbraco.Gandalf.Controllers.Backoffice
     [PluginController("Gandalf")]
     public class AllowedIpApiController : UmbracoAuthorizedApiController
     {
-        private IAllowedIpService _allowedIpServiceCachedProxy;
+        private IAllowedIpService _allowedIpService;
 
-        public AllowedIpApiController(AllowedIpServiceCachedProxy allowedIpServiceCachedProxy)
+        public AllowedIpApiController(AllowedIpService allowedIpService)
         {
-			_allowedIpServiceCachedProxy = allowedIpServiceCachedProxy;
+			_allowedIpService = allowedIpService;
         }
 
 
         [HttpGet]
         public IEnumerable<AllowedIpDto> GetAll()
         {
-            return _allowedIpServiceCachedProxy.GetAll();
+            return _allowedIpService.GetAll();
         }
 
         [HttpPost]
@@ -36,7 +36,7 @@ namespace Our.Umbraco.Gandalf.Controllers.Backoffice
 
             try
             {
-                var item = _allowedIpServiceCachedProxy.Create(request.ipAddress, request.Notes);
+                var item = _allowedIpService.Create(request.ipAddress, request.Notes);
                 return new AddResponse() { Success = true, Item = item };
             }
             catch(Exception e)
@@ -55,7 +55,7 @@ namespace Our.Umbraco.Gandalf.Controllers.Backoffice
 
             try
             {
-                var item = _allowedIpServiceCachedProxy.Update(request.Item);
+                var item = _allowedIpService.Update(request.Item);
                 return new UpdateResponse() { Success = true, Item = item };
             }
             catch (Exception e)
@@ -71,7 +71,7 @@ namespace Our.Umbraco.Gandalf.Controllers.Backoffice
 
             try
             {
-				_allowedIpServiceCachedProxy.Delete(id);
+				_allowedIpService.Delete(id);
                 return new DeleteResponse() { Success = true };
             }
             catch(Exception e)
@@ -83,7 +83,7 @@ namespace Our.Umbraco.Gandalf.Controllers.Backoffice
 		[HttpGet]
 		public StatusResponse GetStatus()
 		{
-			var status = _allowedIpServiceCachedProxy.GetStatus();
+			var status = _allowedIpService.GetStatus();
 			bool.TryParse(status.Value, out bool boolValue);
 
 			return new StatusResponse() { Enabled = boolValue };
@@ -94,7 +94,7 @@ namespace Our.Umbraco.Gandalf.Controllers.Backoffice
 		{
 			try
 			{
-				var item = _allowedIpServiceCachedProxy.UpdateAppStatus(model.CurrentStatus.ToString());
+				var item = _allowedIpService.UpdateAppStatus(model.CurrentStatus.ToString());
 				return new StatusResponse() { Success = true, Message = "Status successfully updated" };
 			}
 			catch (Exception e)

--- a/src/Our.Umbraco.Gandalf/Core/Controllers/Backoffice/AllowedApiController.cs
+++ b/src/Our.Umbraco.Gandalf/Core/Controllers/Backoffice/AllowedApiController.cs
@@ -7,24 +7,25 @@ using System.Web.Mvc;
 using Umbraco.Web.Mvc;
 using Umbraco.Web.WebApi;
 using Our.Umbraco.Gandalf.Core.Models.Api.Request;
+using Our.Umbraco.Gandalf.Core.Services.CachedProxies;
 
 namespace Our.Umbraco.Gandalf.Controllers.Backoffice
 {
     [PluginController("Gandalf")]
     public class AllowedIpApiController : UmbracoAuthorizedApiController
     {
-        private IAllowedIpService _allowedIpService;
+        private IAllowedIpService _allowedIpServiceCachedProxy;
 
-        public AllowedIpApiController(IAllowedIpService allowedIpService)
+        public AllowedIpApiController(AllowedIpServiceCachedProxy allowedIpServiceCachedProxy)
         {
-            _allowedIpService = allowedIpService;
+			_allowedIpServiceCachedProxy = allowedIpServiceCachedProxy;
         }
 
 
         [HttpGet]
         public IEnumerable<AllowedIpDto> GetAll()
         {
-            return _allowedIpService.GetAll();
+            return _allowedIpServiceCachedProxy.GetAll();
         }
 
         [HttpPost]
@@ -35,7 +36,7 @@ namespace Our.Umbraco.Gandalf.Controllers.Backoffice
 
             try
             {
-                var item = _allowedIpService.Create(request.ipAddress, request.Notes);
+                var item = _allowedIpServiceCachedProxy.Create(request.ipAddress, request.Notes);
                 return new AddResponse() { Success = true, Item = item };
             }
             catch(Exception e)
@@ -54,7 +55,7 @@ namespace Our.Umbraco.Gandalf.Controllers.Backoffice
 
             try
             {
-                var item = _allowedIpService.Update(request.Item);
+                var item = _allowedIpServiceCachedProxy.Update(request.Item);
                 return new UpdateResponse() { Success = true, Item = item };
             }
             catch (Exception e)
@@ -70,7 +71,7 @@ namespace Our.Umbraco.Gandalf.Controllers.Backoffice
 
             try
             {
-                _allowedIpService.Delete(id);
+				_allowedIpServiceCachedProxy.Delete(id);
                 return new DeleteResponse() { Success = true };
             }
             catch(Exception e)
@@ -82,7 +83,7 @@ namespace Our.Umbraco.Gandalf.Controllers.Backoffice
 		[HttpGet]
 		public StatusResponse GetStatus()
 		{
-			var status = _allowedIpService.GetStatus();
+			var status = _allowedIpServiceCachedProxy.GetStatus();
 			bool.TryParse(status.Value, out bool boolValue);
 
 			return new StatusResponse() { Enabled = boolValue };
@@ -93,7 +94,7 @@ namespace Our.Umbraco.Gandalf.Controllers.Backoffice
 		{
 			try
 			{
-				var item = _allowedIpService.UpdateAppStatus(model.CurrentStatus.ToString());
+				var item = _allowedIpServiceCachedProxy.UpdateAppStatus(model.CurrentStatus.ToString());
 				return new StatusResponse() { Success = true, Message = "Status successfully updated" };
 			}
 			catch (Exception e)

--- a/src/Our.Umbraco.Gandalf/Core/Services/CachedProxies/AllowedIpServiceCachedProxy.cs
+++ b/src/Our.Umbraco.Gandalf/Core/Services/CachedProxies/AllowedIpServiceCachedProxy.cs
@@ -19,14 +19,16 @@ namespace Our.Umbraco.Gandalf.Core.Services.CachedProxies
 	
 		public AllowedIpDto Create(string ipAddress, string notes)
 		{
-			_runtimeCache.ClearByRegex($"{typeof(AllowedIpServiceCachedProxy)}_(.*)");
-			return this._allowedIpService.Create(ipAddress, notes);
+			var result = this._allowedIpService.Create(ipAddress, notes);
+			_runtimeCache.ClearByRegex($"{typeof(AllowedIpServiceCachedProxy)}(.*)");
+
+			return result;
 		}
 
 		public void Delete(int id)
 		{
-			this._allowedIpService.Delete(id);
 			_runtimeCache.ClearByRegex($"{typeof(AllowedIpServiceCachedProxy)}_(.*)");
+			this._allowedIpService.Delete(id);
 		}
 
 		public IEnumerable<AllowedIpDto> GetAll()
@@ -43,7 +45,7 @@ namespace Our.Umbraco.Gandalf.Core.Services.CachedProxies
 		public AllowedIpDto GetByIpAddress(string ipAddress)
 		{
 			var cacheKey = $"{typeof(AllowedIpServiceCachedProxy)}";
-			return GetAll().FirstOrDefault(a =>a.IpAddress.Equals(ipAddress));
+			return _runtimeCache.GetCacheItem(cacheKey, () => GetByIpAddress(ipAddress));		
 		}
 
 		public KeyValueDto GetStatus()
@@ -53,14 +55,18 @@ namespace Our.Umbraco.Gandalf.Core.Services.CachedProxies
 
 		public AllowedIpDto Update(AllowedIpDto poco)
 		{
-			_runtimeCache.ClearByRegex($"{typeof(AllowedIpServiceCachedProxy)}_(.*)");
-			return this._allowedIpService.Update(poco);
+			var result = this._allowedIpService.Update(poco);
+			_runtimeCache.ClearByRegex($"{typeof(AllowedIpServiceCachedProxy)}(.*)");
+			
+			return result;
+
 		}
 
 		public KeyValueDto UpdateAppStatus(string value)
 		{
+			var result = this._allowedIpService.UpdateAppStatus(value);
 			_runtimeCache.ClearByRegex($"{typeof(AllowedIpServiceCachedProxy)}_(.*)");
-			return this._allowedIpService.UpdateAppStatus(value);
+			return result;
 		}
 
 	}

--- a/src/Our.Umbraco.Gandalf/Core/Services/CachedProxies/AllowedIpServiceCachedProxy.cs
+++ b/src/Our.Umbraco.Gandalf/Core/Services/CachedProxies/AllowedIpServiceCachedProxy.cs
@@ -4,6 +4,7 @@ using DangEasy.Caching.MemoryCache;
 using Our.Umbraco.Gandalf.Core.Models.DTOs;
 using Our.Umbraco.OpenKeyValue.Core.Models.Pocos;
 using System.Linq;
+using Umbraco.Core.Cache;
 
 namespace Our.Umbraco.Gandalf.Core.Services.CachedProxies
 {
@@ -12,11 +13,13 @@ namespace Our.Umbraco.Gandalf.Core.Services.CachedProxies
 
 		private readonly ICache _cache;
 		private readonly IAllowedIpService _allowedIpService;
+		private readonly IAppCache _runtimeCache;
 
-		public AllowedIpServiceCachedProxy(AllowedIpService allowedIpService, ICache cache)
+		public AllowedIpServiceCachedProxy(AllowedIpService allowedIpService, ICache cache, AppCaches appCaches)
 		{
 			_allowedIpService = allowedIpService;
 			_cache = cache;
+			_runtimeCache = appCaches.RuntimeCache;
 		}
 	
 		public AllowedIpDto Create(string ipAddress, string notes)
@@ -28,11 +31,12 @@ namespace Our.Umbraco.Gandalf.Core.Services.CachedProxies
 		{
 			this._allowedIpService.Delete(id);
 			//need to make this clear the cache
+			_runtimeCache.ClearByKey($"{typeof(AllowedIpServiceCachedProxy)}_(.*)");
 		}
 
 		public IEnumerable<AllowedIpDto> GetAll()
 		{
-			var cacheKey = CacheKey.Build<AllowedIpServiceCachedProxy, IEnumerable<AllowedIpDto>>("-1");
+			var cacheKey = CacheKey.Build<AllowedIpServiceCachedProxy, IEnumerable<AllowedIpDto>>("GetAll");
 			return _cache.Get(cacheKey, () => _allowedIpService.GetAll());
 		}
 
@@ -45,6 +49,7 @@ namespace Our.Umbraco.Gandalf.Core.Services.CachedProxies
 		// as this is getting called in the handler I should cache this one
 		public AllowedIpDto GetByIpAddress(string ipAddress)
 		{
+			var cacheKey = CacheKey.Build<AllowedIpServiceCachedProxy, AllowedIpDto>(ipAddress);
 			return GetAll().FirstOrDefault(a =>a.IpAddress.Equals(ipAddress));
 		}
 

--- a/src/Our.Umbraco.Gandalf/Core/Services/CachedProxies/AllowedIpServiceCachedProxy.cs
+++ b/src/Our.Umbraco.Gandalf/Core/Services/CachedProxies/AllowedIpServiceCachedProxy.cs
@@ -24,13 +24,13 @@ namespace Our.Umbraco.Gandalf.Core.Services.CachedProxies
 	
 		public AllowedIpDto Create(string ipAddress, string notes)
 		{
+			_runtimeCache.ClearByKey($"{typeof(AllowedIpServiceCachedProxy)}_(.*)");
 			return this._allowedIpService.Create(ipAddress, notes);
 		}
 
 		public void Delete(int id)
 		{
 			this._allowedIpService.Delete(id);
-			//need to make this clear the cache
 			_runtimeCache.ClearByKey($"{typeof(AllowedIpServiceCachedProxy)}_(.*)");
 		}
 
@@ -40,13 +40,11 @@ namespace Our.Umbraco.Gandalf.Core.Services.CachedProxies
 			return _cache.Get(cacheKey, () => _allowedIpService.GetAll());
 		}
 
-		//doesn't need to be cached as it might only be called by the back office
 		public AllowedIpDto GetById(int id)
 		{
 			return _allowedIpService.GetById(id);
 		}
 
-		// as this is getting called in the handler I should cache this one
 		public AllowedIpDto GetByIpAddress(string ipAddress)
 		{
 			var cacheKey = CacheKey.Build<AllowedIpServiceCachedProxy, AllowedIpDto>(ipAddress);
@@ -60,16 +58,15 @@ namespace Our.Umbraco.Gandalf.Core.Services.CachedProxies
 
 		public AllowedIpDto Update(AllowedIpDto poco)
 		{
+			_runtimeCache.ClearByKey($"{typeof(AllowedIpServiceCachedProxy)}_(.*)");
 			return this._allowedIpService.Update(poco);
 		}
 
 		public KeyValueDto UpdateAppStatus(string value)
 		{
+			_runtimeCache.ClearByKey($"{typeof(AllowedIpServiceCachedProxy)}_(.*)");
 			return this._allowedIpService.UpdateAppStatus(value);
 		}
 
-		// clear cache in the service any time there is a set, AND on a toggle
-
-		// getall response should be cached
 	}
 }

--- a/src/Our.Umbraco.Gandalf/Core/Services/CachedProxies/AllowedIpServiceCachedProxy.cs
+++ b/src/Our.Umbraco.Gandalf/Core/Services/CachedProxies/AllowedIpServiceCachedProxy.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Generic;
-using DangEasy.Interfaces.Caching;
-using DangEasy.Caching.MemoryCache;
 using Our.Umbraco.Gandalf.Core.Models.DTOs;
 using Our.Umbraco.OpenKeyValue.Core.Models.Pocos;
 using System.Linq;
 using Umbraco.Core.Cache;
+using DangEasy.Caching.MemoryCache;
+using DangEasy.Interfaces.Caching;
 
 namespace Our.Umbraco.Gandalf.Core.Services.CachedProxies
 {

--- a/src/Our.Umbraco.Gandalf/Core/Services/CachedProxies/AllowedIpServiceCachedProxy.cs
+++ b/src/Our.Umbraco.Gandalf/Core/Services/CachedProxies/AllowedIpServiceCachedProxy.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Generic;
+using DangEasy.Interfaces.Caching;
+using DangEasy.Caching.MemoryCache;
+using Our.Umbraco.Gandalf.Core.Models.DTOs;
+using Our.Umbraco.OpenKeyValue.Core.Models.Pocos;
+using System.Linq;
+
+namespace Our.Umbraco.Gandalf.Core.Services.CachedProxies
+{
+	public class AllowedIpServiceCachedProxy : IAllowedIpService
+	{
+
+		private readonly ICache _cache;
+		private readonly IAllowedIpService _allowedIpService;
+
+		public AllowedIpServiceCachedProxy(AllowedIpService allowedIpService, ICache cache)
+		{
+			_allowedIpService = allowedIpService;
+			_cache = cache;
+		}
+	
+		public AllowedIpDto Create(string ipAddress, string notes)
+		{
+			return this._allowedIpService.Create(ipAddress, notes);
+		}
+
+		public void Delete(int id)
+		{
+			this._allowedIpService.Delete(id);
+			//need to make this clear the cache
+		}
+
+		public IEnumerable<AllowedIpDto> GetAll()
+		{
+			var cacheKey = CacheKey.Build<AllowedIpServiceCachedProxy, IEnumerable<AllowedIpDto>>("-1");
+			return _cache.Get(cacheKey, () => _allowedIpService.GetAll());
+		}
+
+		//doesn't need to be cached as it might only be called by the back office
+		public AllowedIpDto GetById(int id)
+		{
+			return _allowedIpService.GetById(id);
+		}
+
+		// as this is getting called in the handler I should cache this one
+		public AllowedIpDto GetByIpAddress(string ipAddress)
+		{
+			return GetAll().FirstOrDefault(a =>a.IpAddress.Equals(ipAddress));
+		}
+
+		public KeyValueDto GetStatus()
+		{
+			return this._allowedIpService.GetStatus();
+		}
+
+		public AllowedIpDto Update(AllowedIpDto poco)
+		{
+			return this._allowedIpService.Update(poco);
+		}
+
+		public KeyValueDto UpdateAppStatus(string value)
+		{
+			return this._allowedIpService.UpdateAppStatus(value);
+		}
+
+		// clear cache in the service any time there is a set, AND on a toggle
+
+		// getall response should be cached
+	}
+}

--- a/src/Our.Umbraco.Gandalf/Core/Services/CachedProxies/AllowedIpServiceCachedProxy.cs
+++ b/src/Our.Umbraco.Gandalf/Core/Services/CachedProxies/AllowedIpServiceCachedProxy.cs
@@ -3,41 +3,36 @@ using Our.Umbraco.Gandalf.Core.Models.DTOs;
 using Our.Umbraco.OpenKeyValue.Core.Models.Pocos;
 using System.Linq;
 using Umbraco.Core.Cache;
-using DangEasy.Caching.MemoryCache;
-using DangEasy.Interfaces.Caching;
 
 namespace Our.Umbraco.Gandalf.Core.Services.CachedProxies
 {
 	public class AllowedIpServiceCachedProxy : IAllowedIpService
 	{
-
-		private readonly ICache _cache;
 		private readonly IAllowedIpService _allowedIpService;
 		private readonly IAppCache _runtimeCache;
 
-		public AllowedIpServiceCachedProxy(AllowedIpService allowedIpService, ICache cache, AppCaches appCaches)
+		public AllowedIpServiceCachedProxy(AllowedIpService allowedIpService, AppCaches appCaches)
 		{
 			_allowedIpService = allowedIpService;
-			_cache = cache;
 			_runtimeCache = appCaches.RuntimeCache;
 		}
 	
 		public AllowedIpDto Create(string ipAddress, string notes)
 		{
-			_runtimeCache.ClearByKey($"{typeof(AllowedIpServiceCachedProxy)}_(.*)");
+			_runtimeCache.ClearByRegex($"{typeof(AllowedIpServiceCachedProxy)}_(.*)");
 			return this._allowedIpService.Create(ipAddress, notes);
 		}
 
 		public void Delete(int id)
 		{
 			this._allowedIpService.Delete(id);
-			_runtimeCache.ClearByKey($"{typeof(AllowedIpServiceCachedProxy)}_(.*)");
+			_runtimeCache.ClearByRegex($"{typeof(AllowedIpServiceCachedProxy)}_(.*)");
 		}
 
 		public IEnumerable<AllowedIpDto> GetAll()
 		{
-			var cacheKey = CacheKey.Build<AllowedIpServiceCachedProxy, IEnumerable<AllowedIpDto>>("GetAll");
-			return _cache.Get(cacheKey, () => _allowedIpService.GetAll());
+			var cacheKey = $"{typeof(AllowedIpServiceCachedProxy)}";
+			return _runtimeCache.GetCacheItem(cacheKey, () => _allowedIpService.GetAll());
 		}
 
 		public AllowedIpDto GetById(int id)
@@ -47,7 +42,7 @@ namespace Our.Umbraco.Gandalf.Core.Services.CachedProxies
 
 		public AllowedIpDto GetByIpAddress(string ipAddress)
 		{
-			var cacheKey = CacheKey.Build<AllowedIpServiceCachedProxy, AllowedIpDto>(ipAddress);
+			var cacheKey = $"{typeof(AllowedIpServiceCachedProxy)}";
 			return GetAll().FirstOrDefault(a =>a.IpAddress.Equals(ipAddress));
 		}
 
@@ -58,13 +53,13 @@ namespace Our.Umbraco.Gandalf.Core.Services.CachedProxies
 
 		public AllowedIpDto Update(AllowedIpDto poco)
 		{
-			_runtimeCache.ClearByKey($"{typeof(AllowedIpServiceCachedProxy)}_(.*)");
+			_runtimeCache.ClearByRegex($"{typeof(AllowedIpServiceCachedProxy)}_(.*)");
 			return this._allowedIpService.Update(poco);
 		}
 
 		public KeyValueDto UpdateAppStatus(string value)
 		{
-			_runtimeCache.ClearByKey($"{typeof(AllowedIpServiceCachedProxy)}_(.*)");
+			_runtimeCache.ClearByRegex($"{typeof(AllowedIpServiceCachedProxy)}_(.*)");
 			return this._allowedIpService.UpdateAppStatus(value);
 		}
 

--- a/src/Our.Umbraco.Gandalf/Core/Services/CachedProxies/AllowedIpServiceCachedProxy.cs
+++ b/src/Our.Umbraco.Gandalf/Core/Services/CachedProxies/AllowedIpServiceCachedProxy.cs
@@ -16,25 +16,24 @@ namespace Our.Umbraco.Gandalf.Core.Services.CachedProxies
 			_allowedIpService = allowedIpService;
 			_runtimeCache = appCaches.RuntimeCache;
 		}
-	
+
 		public AllowedIpDto Create(string ipAddress, string notes)
 		{
 			var result = this._allowedIpService.Create(ipAddress, notes);
-			_runtimeCache.ClearByRegex($"{typeof(AllowedIpServiceCachedProxy)}(.*)");
+			ClearCache();
 
 			return result;
 		}
 
 		public void Delete(int id)
 		{
-			_runtimeCache.ClearByRegex($"{typeof(AllowedIpServiceCachedProxy)}_(.*)");
+			ClearCache();
 			this._allowedIpService.Delete(id);
 		}
 
 		public IEnumerable<AllowedIpDto> GetAll()
 		{
-			var cacheKey = $"{typeof(AllowedIpServiceCachedProxy)}";
-			return _runtimeCache.GetCacheItem(cacheKey, () => _allowedIpService.GetAll());
+			return _allowedIpService.GetAll();
 		}
 
 		public AllowedIpDto GetById(int id)
@@ -44,8 +43,9 @@ namespace Our.Umbraco.Gandalf.Core.Services.CachedProxies
 
 		public AllowedIpDto GetByIpAddress(string ipAddress)
 		{
-			var cacheKey = $"{typeof(AllowedIpServiceCachedProxy)}";
-			return _runtimeCache.GetCacheItem(cacheKey, () => GetByIpAddress(ipAddress));		
+			var cacheKey = $"{typeof(AllowedIpServiceCachedProxy)}_{ipAddress}";
+
+			return _runtimeCache.GetCacheItem(cacheKey, () => _allowedIpService.GetByIpAddress(ipAddress));
 		}
 
 		public KeyValueDto GetStatus()
@@ -56,8 +56,8 @@ namespace Our.Umbraco.Gandalf.Core.Services.CachedProxies
 		public AllowedIpDto Update(AllowedIpDto poco)
 		{
 			var result = this._allowedIpService.Update(poco);
-			_runtimeCache.ClearByRegex($"{typeof(AllowedIpServiceCachedProxy)}(.*)");
-			
+			ClearCache();
+
 			return result;
 
 		}
@@ -65,9 +65,14 @@ namespace Our.Umbraco.Gandalf.Core.Services.CachedProxies
 		public KeyValueDto UpdateAppStatus(string value)
 		{
 			var result = this._allowedIpService.UpdateAppStatus(value);
-			_runtimeCache.ClearByRegex($"{typeof(AllowedIpServiceCachedProxy)}_(.*)");
+			ClearCache();
+
 			return result;
 		}
 
+		private void ClearCache()
+		{
+			_runtimeCache.ClearByRegex($"{typeof(AllowedIpServiceCachedProxy)}_(.*)");
+		}
 	}
 }

--- a/src/Our.Umbraco.Gandalf/Core/StartUp/IpLockerComposer.cs
+++ b/src/Our.Umbraco.Gandalf/Core/StartUp/IpLockerComposer.cs
@@ -21,11 +21,12 @@ namespace Our.Umbraco.Gandalf.Core.StartUp
 
 			if (ConfigurationManager.AppSettings["AllowedIpServiceCache:Enabled"] == "true")
 			{
-				composition.Register(typeof(IAllowedIpService), typeof(AllowedIpServiceCachedProxy));
-	}
+				composition.Register<AllowedIpService, AllowedIpService>();
+				composition.Register<IAllowedIpService, AllowedIpServiceCachedProxy>();
+			}
 			else
 			{
-				composition.Register(typeof(IAllowedIpService), typeof(AllowedIpService));
+				composition.Register<IAllowedIpService, AllowedIpService>();
 			}
 		}
 	}

--- a/src/Our.Umbraco.Gandalf/Core/StartUp/IpLockerComposer.cs
+++ b/src/Our.Umbraco.Gandalf/Core/StartUp/IpLockerComposer.cs
@@ -4,8 +4,6 @@ using Our.Umbraco.Gandalf.Core.Repositories;
 using Our.Umbraco.Gandalf.Core.Services;
 using System.Configuration;
 using System.ComponentModel;
-using DangEasy.Interfaces.Caching;
-using DangEasy.Caching.MemoryCache;
 using Umbraco.Core;
 using Our.Umbraco.Gandalf.Core.Services.CachedProxies;
 
@@ -16,8 +14,6 @@ namespace Our.Umbraco.Gandalf.Core.StartUp
 
 		public void Compose(Composition composition)
 		{
-			composition.Register(typeof(ICache), typeof(Cache));
-
 			if (ConfigurationManager.AppSettings["AllowedIpServiceCache:Enabled"] == "true")
 			{
 				composition.Register<AllowedIpService, AllowedIpService>();

--- a/src/Our.Umbraco.Gandalf/Core/StartUp/IpLockerComposer.cs
+++ b/src/Our.Umbraco.Gandalf/Core/StartUp/IpLockerComposer.cs
@@ -2,6 +2,10 @@
 using Umbraco.Core.Composing;
 using Our.Umbraco.Gandalf.Core.Repositories;
 using Our.Umbraco.Gandalf.Core.Services;
+using System.Configuration;
+using System.ComponentModel;
+using Umbraco.Core;
+using Our.Umbraco.Gandalf.Core.Services.CachedProxies;
 
 namespace Our.Umbraco.Gandalf.Core.StartUp
 {
@@ -9,11 +13,20 @@ namespace Our.Umbraco.Gandalf.Core.StartUp
 	{
 		public void Compose(Composition composition)
 		{
-			composition.Register(typeof(IAllowedIpService), typeof(AllowedIpService));
+			//composition.Register(typeof(IAllowedIpService), typeof(AllowedIpService));
 			composition.Register(typeof(IRepository), typeof(AllowedIpRepository));
 
 			composition.ContentFinders().Insert<NotAllowedLastChangeContentFinder>(0);
 			composition.ContentFinders().Insert<AllowedIpContentFinder>(1);
+
+			if (ConfigurationManager.AppSettings["AllowedIpServiceCache:Enabled"] == "true")
+			{
+				composition.Register(typeof(IAllowedIpService), typeof(AllowedIpServiceCachedProxy));
+	}
+			else
+			{
+				composition.Register(typeof(IAllowedIpService), typeof(AllowedIpService));
+			}
 		}
 	}
 }

--- a/src/Our.Umbraco.Gandalf/Core/StartUp/IpLockerComposer.cs
+++ b/src/Our.Umbraco.Gandalf/Core/StartUp/IpLockerComposer.cs
@@ -32,9 +32,6 @@ namespace Our.Umbraco.Gandalf.Core.StartUp
 			composition.ContentFinders().Insert<NotAllowedLastChangeContentFinder>(0);
 			composition.ContentFinders().Insert<AllowedIpContentFinder>(1);
 
-			//register the dangeasy caching stuff
-
-
 		}
 	}
 }

--- a/src/Our.Umbraco.Gandalf/Core/StartUp/IpLockerComposer.cs
+++ b/src/Our.Umbraco.Gandalf/Core/StartUp/IpLockerComposer.cs
@@ -14,7 +14,7 @@ namespace Our.Umbraco.Gandalf.Core.StartUp
 
 		public void Compose(Composition composition)
 		{
-			if (ConfigurationManager.AppSettings["AllowedIpServiceCache:Enabled"] == "true")
+			if (ConfigurationManager.AppSettings["AllowedIpServiceCache:Enabled"] == "true" || ConfigurationManager.AppSettings["AllowedIpServiceCache:Enabled"] == null)
 			{
 				composition.Register<AllowedIpService, AllowedIpService>();
 				composition.Register<IAllowedIpService, AllowedIpServiceCachedProxy>();

--- a/src/Our.Umbraco.Gandalf/Core/StartUp/IpLockerComposer.cs
+++ b/src/Our.Umbraco.Gandalf/Core/StartUp/IpLockerComposer.cs
@@ -4,6 +4,8 @@ using Our.Umbraco.Gandalf.Core.Repositories;
 using Our.Umbraco.Gandalf.Core.Services;
 using System.Configuration;
 using System.ComponentModel;
+using DangEasy.Interfaces.Caching;
+using DangEasy.Caching.MemoryCache;
 using Umbraco.Core;
 using Our.Umbraco.Gandalf.Core.Services.CachedProxies;
 
@@ -11,13 +13,10 @@ namespace Our.Umbraco.Gandalf.Core.StartUp
 {
 	public class GandalfComposer : IUserComposer
 	{
+
 		public void Compose(Composition composition)
 		{
-			//composition.Register(typeof(IAllowedIpService), typeof(AllowedIpService));
-			composition.Register(typeof(IRepository), typeof(AllowedIpRepository));
-
-			composition.ContentFinders().Insert<NotAllowedLastChangeContentFinder>(0);
-			composition.ContentFinders().Insert<AllowedIpContentFinder>(1);
+			composition.Register(typeof(ICache), typeof(Cache));
 
 			if (ConfigurationManager.AppSettings["AllowedIpServiceCache:Enabled"] == "true")
 			{
@@ -28,6 +27,14 @@ namespace Our.Umbraco.Gandalf.Core.StartUp
 			{
 				composition.Register<IAllowedIpService, AllowedIpService>();
 			}
+			composition.Register(typeof(IRepository), typeof(AllowedIpRepository));
+
+			composition.ContentFinders().Insert<NotAllowedLastChangeContentFinder>(0);
+			composition.ContentFinders().Insert<AllowedIpContentFinder>(1);
+
+			//register the dangeasy caching stuff
+
+
 		}
 	}
 }

--- a/src/Our.Umbraco.Gandalf/Our.Umbraco.Gandalf.csproj
+++ b/src/Our.Umbraco.Gandalf/Our.Umbraco.Gandalf.csproj
@@ -48,6 +48,12 @@
     <Reference Include="CSharpTest.Net.Collections, Version=14.906.1403.1082, Culture=neutral, PublicKeyToken=06aee00cce822474, processorArchitecture=MSIL">
       <HintPath>..\packages\CSharpTest.Net.Collections.14.906.1403.1082\lib\net40\CSharpTest.Net.Collections.dll</HintPath>
     </Reference>
+    <Reference Include="DangEasy.Caching.MemoryCache, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DangEasy.Caching.MemoryCache.2.1.0\lib\net472\DangEasy.Caching.MemoryCache.dll</HintPath>
+    </Reference>
+    <Reference Include="DangEasy.Interfaces.Caching, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DangEasy.Interfaces.Caching.2.1.0\lib\net472\DangEasy.Interfaces.Caching.dll</HintPath>
+    </Reference>
     <Reference Include="Examine, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Examine.1.0.0\lib\net452\Examine.dll</HintPath>
     </Reference>
@@ -281,6 +287,7 @@
     <Compile Include="Core\Extensions\AllowedIpExtensions.cs" />
     <Compile Include="Core\Models\DTOs\AllowedIpDto.cs" />
     <Compile Include="Core\Services\AllowedIpService.cs" />
+    <Compile Include="Core\Services\CachedProxies\AllowedIpServiceCachedProxy.cs" />
     <Compile Include="Core\StartUp\Migrations\MigrationsComposer.cs" />
     <Compile Include="Core\Extensions\StringExtensions.cs" />
     <Compile Include="Core\Repositories\IRepository.cs" />

--- a/src/Our.Umbraco.Gandalf/Our.Umbraco.Gandalf.csproj
+++ b/src/Our.Umbraco.Gandalf/Our.Umbraco.Gandalf.csproj
@@ -48,12 +48,6 @@
     <Reference Include="CSharpTest.Net.Collections, Version=14.906.1403.1082, Culture=neutral, PublicKeyToken=06aee00cce822474, processorArchitecture=MSIL">
       <HintPath>..\packages\CSharpTest.Net.Collections.14.906.1403.1082\lib\net40\CSharpTest.Net.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="DangEasy.Caching.MemoryCache, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DangEasy.Caching.MemoryCache.2.1.0\lib\net472\DangEasy.Caching.MemoryCache.dll</HintPath>
-    </Reference>
-    <Reference Include="DangEasy.Interfaces.Caching, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DangEasy.Interfaces.Caching.2.1.0\lib\net472\DangEasy.Interfaces.Caching.dll</HintPath>
-    </Reference>
     <Reference Include="Examine, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Examine.1.0.0\lib\net452\Examine.dll</HintPath>
     </Reference>

--- a/src/Our.Umbraco.Gandalf/packages.config
+++ b/src/Our.Umbraco.Gandalf/packages.config
@@ -4,8 +4,6 @@
   <package id="ClientDependency" version="1.9.7" targetFramework="net472" />
   <package id="ClientDependency-Mvc5" version="1.8.0.0" targetFramework="net452" />
   <package id="CSharpTest.Net.Collections" version="14.906.1403.1082" targetFramework="net472" />
-  <package id="DangEasy.Caching.MemoryCache" version="2.1.0" targetFramework="net472" />
-  <package id="DangEasy.Interfaces.Caching" version="2.1.0" targetFramework="net472" />
   <package id="Examine" version="1.0.0" targetFramework="net472" />
   <package id="HtmlAgilityPack" version="1.8.14" targetFramework="net472" />
   <package id="ImageProcessor" version="2.7.0.100" targetFramework="net472" />

--- a/src/Our.Umbraco.Gandalf/packages.config
+++ b/src/Our.Umbraco.Gandalf/packages.config
@@ -4,6 +4,8 @@
   <package id="ClientDependency" version="1.9.7" targetFramework="net472" />
   <package id="ClientDependency-Mvc5" version="1.8.0.0" targetFramework="net452" />
   <package id="CSharpTest.Net.Collections" version="14.906.1403.1082" targetFramework="net472" />
+  <package id="DangEasy.Caching.MemoryCache" version="2.1.0" targetFramework="net472" />
+  <package id="DangEasy.Interfaces.Caching" version="2.1.0" targetFramework="net472" />
   <package id="Examine" version="1.0.0" targetFramework="net472" />
   <package id="HtmlAgilityPack" version="1.8.14" targetFramework="net472" />
   <package id="ImageProcessor" version="2.7.0.100" targetFramework="net472" />
@@ -59,6 +61,7 @@
   <package id="SharpZipLib" version="0.86.0" targetFramework="net452" />
   <package id="Superpower" version="2.0.0" targetFramework="net472" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net472" />
+  <package id="System.Runtime.Caching" version="4.5.0" targetFramework="net472" />
   <package id="System.Threading.Tasks.Dataflow" version="4.9.0" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
   <package id="Umbraco.SqlServerCE" version="4.0.0.1" targetFramework="net472" />


### PR DESCRIPTION
Cached proxy pattern implemented using https://skrift.io/articles/archive/a-perspective-on-caching-in-umbraco/ as a guide. Installed using DangEasy.Interfaces.Caching &
using DangEasy.Caching.MemoryCache packages to assist. 