### PR TITLE
Hotfix1 js get post error ajax call removed and conditional inverted to whitelist

### DIFF
--- a/src/Our.Umbraco.Gandalf/Core/AllowedIpContentFinder.cs
+++ b/src/Our.Umbraco.Gandalf/Core/AllowedIpContentFinder.cs
@@ -24,7 +24,7 @@ namespace Our.Umbraco.Gandalf.Core
 			var ip = request.UmbracoContext.HttpContext.Request.UserHostAddress;
 			var item = _allowedIpService.GetByIpAddress(ip);
 
-			if (item != null)
+			if (item == null)
 			{
 				request.SetRedirect("/ip-not-allowed");
 

--- a/src/Our.Umbraco.Gandalf/UI/App_Plugins/Our.Umbraco.Gandalf/assets/scripts/app.js
+++ b/src/Our.Umbraco.Gandalf/UI/App_Plugins/Our.Umbraco.Gandalf/assets/scripts/app.js
@@ -274,7 +274,7 @@ angular.module("umbraco.resources").factory("GandalfApi", function ($http) {
 
         //Toggle status
         toggleStatus: function (data) {
-            return $http.post("backoffice/Gandalf/AllowedIpApi/ToggleStatus", { currentStatus: data }).then(successCallback, errorCallback);
+            return $http.post("backoffice/Gandalf/AllowedIpApi/ToggleStatus", { currentStatus: data });
         },
 
         //return status

--- a/src/Our.Umbraco.Gandalf/UI/App_Plugins/Our.Umbraco.Gandalf/assets/scripts/app.js
+++ b/src/Our.Umbraco.Gandalf/UI/App_Plugins/Our.Umbraco.Gandalf/assets/scripts/app.js
@@ -279,7 +279,7 @@ angular.module("umbraco.resources").factory("GandalfApi", function ($http) {
 
         //return status
         getStatus: function () {
-            return $http.post("backoffice/Gandalf/AllowedIpApi/getStatus");
+            return $http.get("backoffice/Gandalf/AllowedIpApi/getStatus");
         }
     };
 });


### PR DESCRIPTION
Gandalf was blacklisting rather than whitelisting. That's now sorted. The ajax call is gone and the get was trying to post but that's also fixed.